### PR TITLE
fix: test for new thumbprint

### DIFF
--- a/test/provider.test.ts
+++ b/test/provider.test.ts
@@ -16,6 +16,7 @@ test('New Provider', () => {
     ],
     ThumbprintList: [
       'a031c46782e6e6c662c2c87c76da9aa62ccabd8e',
+      '6938fd4d98bab03faadb97b34396831e3780aea1',
     ],
     Url: 'https://token.actions.githubusercontent.com',
   });


### PR DESCRIPTION
Update tests to accommodate for the new Github OIDC thumbprint. 