### PR TITLE
feat: add support for go version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,3 +127,28 @@ jobs:
         run: cd .repo && npx projen package:python
       - name: Collect python Artifact
         run: mv .repo/dist dist
+  package-go:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions: {}
+    if: "! needs.build.outputs.self_mutation_happened"
+    steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16.0
+      - name: Download build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: build-artifact
+          path: dist
+      - name: Prepare Repository
+        run: mv dist .repo
+      - name: Install Dependencies
+        run: cd .repo && yarn install --check-files --frozen-lockfile
+      - name: Create go artifact
+        run: cd .repo && npx projen package:go
+      - name: Collect go Artifact
+        run: mv .repo/dist dist

--- a/.github/workflows/release-cdkv1.yml
+++ b/.github/workflows/release-cdkv1.yml
@@ -127,3 +127,36 @@ jobs:
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+  release_golang:
+    name: Publish to GitHub Go Module Repository
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: needs.release.outputs.latest_commit == github.sha
+    steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16.0
+      - name: Download build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: build-artifact
+          path: dist
+      - name: Prepare Repository
+        run: mv dist .repo
+      - name: Install Dependencies
+        run: cd .repo && yarn install --check-files --frozen-lockfile
+      - name: Create go artifact
+        run: cd .repo && npx projen package:go
+      - name: Collect go Artifact
+        run: mv .repo/dist dist
+      - name: Release
+        run: npx -p publib@latest publib-golang
+        env:
+          GIT_USER_NAME: github-actions
+          GIT_USER_EMAIL: github-actions@github.com
+          GITHUB_TOKEN: ${{ secrets.GO_GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,3 +127,36 @@ jobs:
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+  release_golang:
+    name: Publish to GitHub Go Module Repository
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: needs.release.outputs.latest_commit == github.sha
+    steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16.0
+      - name: Download build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: build-artifact
+          path: dist
+      - name: Prepare Repository
+        run: mv dist .repo
+      - name: Install Dependencies
+        run: cd .repo && yarn install --check-files --frozen-lockfile
+      - name: Create go artifact
+        run: cd .repo && npx projen package:go
+      - name: Collect go Artifact
+        run: mv .repo/dist dist
+      - name: Release
+        run: npx -p publib@latest publib-golang
+        env:
+          GIT_USER_NAME: github-actions
+          GIT_USER_EMAIL: github-actions@github.com
+          GITHUB_TOKEN: ${{ secrets.GO_GITHUB_TOKEN }}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,6 +8,7 @@ queue_rules:
       - status-success=build
       - status-success=package-js
       - status-success=package-python
+      - status-success=package-go
 pull_request_rules:
   - name: Automatic merge on approval and successful build
     actions:
@@ -25,3 +26,4 @@ pull_request_rules:
       - status-success=build
       - status-success=package-js
       - status-success=package-python
+      - status-success=package-go

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -147,6 +147,21 @@
         },
         {
           "spawn": "package:python"
+        },
+        {
+          "spawn": "package:go"
+        }
+      ]
+    },
+    "package:go": {
+      "name": "package:go",
+      "description": "Create go language bindings",
+      "steps": [
+        {
+          "exec": "jsii_version=$(node -p \"JSON.parse(fs.readFileSync('.jsii')).jsiiVersion.split(' ')[0]\")"
+        },
+        {
+          "exec": "npx jsii-pacmak@$jsii_version -v --target go"
         }
       ]
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -39,6 +39,10 @@ const project = new awscdk.AwsCdkConstructLibrary({
     module: 'aws_cdk_github_oidc',
   },
 
+  publishToGo: {
+    moduleName: 'github.com/aripalo/aws-cdk-github-oidc-go',
+  },
+
   codeCov: true,
 });
 project.synth();

--- a/README.md
+++ b/README.md
@@ -142,4 +142,4 @@ These constructs are fresh out from the oven, since [Github just announced](http
 
 These constructs will stay in `v0.x.x` for a while, to allow easier bug fixing & breaking changes _if absolutely needed_. Once bugs are fixed (if any), the constructs will be published with `v1` major version and will be marked as stable.
 
-Currently only TypeScript and Python versions provided, but before going to stable, I'll probably others (supported by JSII) depending on the amount of work required - so no promises!
+Currently only TypeScript, Python and Go versions provided, but before going to stable, I'll probably others (supported by JSII) depending on the amount of work required - so no promises!

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "eslint": "npx projen eslint",
     "package": "npx projen package",
     "package-all": "npx projen package-all",
+    "package:go": "npx projen package:go",
     "package:js": "npx projen package:js",
     "package:python": "npx projen package:python",
     "post-compile": "npx projen post-compile",
@@ -128,6 +129,9 @@
       "python": {
         "distName": "aws-cdk-github-oidc",
         "module": "aws_cdk_github_oidc"
+      },
+      "go": {
+        "moduleName": "github.com/aripalo/aws-cdk-github-oidc-go"
       }
     },
     "tsc": {


### PR DESCRIPTION
This PR adds Go bindings to the constructs. For this to actually be usable you'd need to setup a repo to where the generated go module would be pushed ie. `https://github.com/aripalo/aws-cdk-github-oidc-go` and generate a token for the github actions to do the release. Given that the jsii support for Go is experimental I understand if that's something that you're not willing to do.