### PR TITLE
feat: support passing multiple trustedRepositories

### DIFF
--- a/API.md
+++ b/API.md
@@ -157,10 +157,10 @@ There can be only one (per AWS Account).
 ##### `repo`<sup>Required</sup> <a name="aws-cdk-github-oidc.GithubActionsRoleProps.property.repo"></a>
 
 ```typescript
-public readonly repo: string;
+public readonly repo: string | string[];
 ```
 
-- *Type:* `string`
+- *Type:* `string` | `string`[]
 
 Repository name (slug) without the owner.
 
@@ -381,10 +381,10 @@ There can be only one (per AWS Account).
 ##### `repo`<sup>Required</sup> <a name="aws-cdk-github-oidc.GithubConfiguration.property.repo"></a>
 
 ```typescript
-public readonly repo: string;
+public readonly repo: string | string[];
 ```
 
-- *Type:* `string`
+- *Type:* `string` | `string`[]
 
 Repository name (slug) without the owner.
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,27 @@ const uploadRole = new GithubActionsRole(scope, "UploadRole", {
 myBucket.grantWrite(uploadRole);
 ```
 
+You can also pass multiple trusted repositories with the `trustedRepositories` property:
+
+```ts
+import { GithubActionsRole } from "aws-cdk-github-oidc";
+
+const uploadRole = new GithubActionsRole(stack, 'TestRole', {
+  provider,
+  trustedRepositories: [
+    {
+      owner: 'octo-org',
+      repo: 'octo-repo1',
+    },
+    {
+      owner: 'octo-org',
+      repo: 'octo-repo2',
+      filter: 'ref:refs/tags/v*',
+    },
+  ],
+});
+```
+
 You may pass in any `iam.RoleProps` into the construct's props, except `assumedBy` which will be defined by this construct (CDK will fail if you do):
 
 ```ts

--- a/src/role.ts
+++ b/src/role.ts
@@ -59,7 +59,7 @@ export interface GithubConfiguration {
   /**
    * Provide multiple trusted repositories allowed to assume this role.
    *
-   * @default - required if top-level owner/repo not set
+   * @default - required if top-level owner/repo/filter not set
    */
   readonly trustedRepositories?: TrustedRepository[];
 }

--- a/test/role.test.ts
+++ b/test/role.test.ts
@@ -26,10 +26,10 @@ test('Role with defaults', () => {
           Action: 'sts:AssumeRoleWithWebIdentity',
           Effect: 'Allow',
           Condition: {
-            StringLike: {
-              'token.actions.githubusercontent.com:sub': 'repo:octo-org/octo-repo:*',
+            'ForAnyValue:StringLike': {
+              'token.actions.githubusercontent.com:sub': ['repo:octo-org/octo-repo:*'],
             },
-            StringEquals: {
+            'StringEquals': {
               'token.actions.githubusercontent.com:aud': 'sts.amazonaws.com',
             },
           },
@@ -88,10 +88,10 @@ test('Role with custom props', () => {
           Action: 'sts:AssumeRoleWithWebIdentity',
           Effect: 'Allow',
           Condition: {
-            StringLike: {
-              'token.actions.githubusercontent.com:sub': 'repo:octo-org/octo-repo:ref:refs/tags/v*',
+            'ForAnyValue:StringLike': {
+              'token.actions.githubusercontent.com:sub': ['repo:octo-org/octo-repo:ref:refs/tags/v*'],
             },
-            StringEquals: {
+            'StringEquals': {
               'token.actions.githubusercontent.com:aud': 'sts.amazonaws.com',
             },
           },

--- a/test/role.test.ts
+++ b/test/role.test.ts
@@ -53,6 +53,65 @@ test('Role with defaults', () => {
   });
 });
 
+test('Role with multiple trusted repositories', () => {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app);
+  const provider = GithubActionsIdentityProvider.fromAccount(stack, 'GithubProvider');
+
+  new GithubActionsRole(stack, 'TestRole', {
+    provider,
+    trustedRepositories: [
+      {
+        owner: 'octo-org',
+        repo: 'octo-repo1',
+      },
+      {
+        owner: 'octo-org',
+        repo: 'octo-repo2',
+        filter: 'ref:refs/tags/v*',
+      },
+    ],
+  });
+
+  const template = Template.fromStack(stack);
+
+  template.hasResourceProperties('AWS::IAM::Role', {
+    AssumeRolePolicyDocument: Match.objectLike({
+      Statement: Match.arrayWith([
+        Match.objectLike({
+          Action: 'sts:AssumeRoleWithWebIdentity',
+          Effect: 'Allow',
+          Condition: {
+            'ForAnyValue:StringLike': {
+              'token.actions.githubusercontent.com:sub': [
+                'repo:octo-org/octo-repo1:*',
+                'repo:octo-org/octo-repo2:ref:refs/tags/v*',
+              ],
+            },
+            'StringEquals': {
+              'token.actions.githubusercontent.com:aud': 'sts.amazonaws.com',
+            },
+          },
+          Principal: {
+            Federated: {
+              'Fn::Join': [
+                '',
+                [
+                  'arn:aws:iam::',
+                  {
+                    Ref: 'AWS::AccountId',
+                  },
+                  ':oidc-provider/token.actions.githubusercontent.com',
+                ],
+              ],
+            },
+          },
+        }),
+      ]),
+    }),
+  });
+});
+
 test('Role with custom props', () => {
 
   const app = new cdk.App();
@@ -185,5 +244,43 @@ test('Role with invalid repo', () => {
   expect(stack.node.metadata).toHaveLength(1);
   expect(stack.node.metadata[0].data).toBe(
     'Invalid Github Repository Name "". May not be empty string.',
+  );
+});
+
+test('Role with top-level props and trustedRepositories set', () => {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app);
+  const provider = GithubActionsIdentityProvider.fromAccount(stack, 'GithubProvider');
+
+  new GithubActionsRole(stack, 'TestRole', {
+    provider,
+    owner: 'octo-org',
+    repo: 'octo-repo',
+    trustedRepositories: [
+      {
+        owner: 'octo-org',
+        repo: 'octo-repo',
+      },
+    ],
+  });
+
+  expect(stack.node.metadata).toHaveLength(1);
+  expect(stack.node.metadata[0].data).toBe(
+    'Cannot set both top-level owner/repo/filter and trustedRepositories. Use one or the other.',
+  );
+});
+
+test('Role without trustedRepositories or top-level props set', () => {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app);
+  const provider = GithubActionsIdentityProvider.fromAccount(stack, 'GithubProvider');
+
+  new GithubActionsRole(stack, 'TestRole', {
+    provider,
+  });
+
+  expect(stack.node.metadata).toHaveLength(1);
+  expect(stack.node.metadata[0].data).toBe(
+    "If you don't provide `trustedRepositories`, you must provide `owner` and `repo`.",
   );
 });


### PR DESCRIPTION
This PR introduces a new API that allows passing multiple subjects via the `trustedRepositories` property.

Fixes #35