### PR TITLE
chore: migration test suite

### DIFF
--- a/migration-test/.gitignore
+++ b/migration-test/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+cdk.out/
+.tmp/

--- a/migration-test/README.md
+++ b/migration-test/README.md
@@ -1,0 +1,66 @@
+# Migration Test Harness
+
+This folder contains an isolated CDK app that exercises a real migration flow for `aws-cdk-github-oidc`:
+
+1. `aws-cdk-github-oidc@^2` with `aws-cdk-lib@2.220.0`
+2. `aws-cdk-github-oidc@^3.1` with exact `aws-cdk-lib@2.237.0`
+3. `aws-cdk-github-oidc@^4.2` with `aws-cdk-lib@^2.237.0`
+
+All CDK commands are executed with `pnpm exec cdk ...`.
+`pnpm-workspace.yaml` in this folder mirrors the root workspace policy values.
+
+## Stack behavior by phase
+
+The app reads `MIGRATION_PHASE` and switches provider implementation:
+
+- `v2`: `new GithubActionsIdentityProvider(this, "GithubProvider")`
+- `v3-retain`: same as `v2`, but with `removalPolicy: cdk.RemovalPolicy.RETAIN`
+- `v4-lookup`: `GithubActionsIdentityProvider.fromAccount(this, "GithubProviderReference")`
+- `v4-import`: switch back to `new GithubActionsIdentityProvider(this, "GithubProvider", { removalPolicy: RETAIN })`
+
+## Setup
+
+From this directory:
+
+```sh
+corepack use pnpm@10.19.0
+pnpm install
+```
+
+## Run full migration flow
+
+```sh
+pnpm run test-migration
+```
+
+Optional environment variable:
+
+- `MIGRATION_STACK_NAME` (default: `AwsCdkGithubOidcMigrationTest`)
+
+## What the script does
+
+`scripts/run-migration.sh` performs the full sequence with deploy boundaries:
+
+1. Install v2 + `aws-cdk-lib@2.220.0`, deploy `MIGRATION_PHASE=v2`
+2. Upgrade to v3.1 + `aws-cdk-lib@2.237.0`, diff and deploy `MIGRATION_PHASE=v3-retain`
+3. Upgrade to v4.2 + `aws-cdk-lib@^2.237.0`, diff and deploy `MIGRATION_PHASE=v4-lookup`
+4. Set `MIGRATION_PHASE=v4-import`, dynamically fetch account id via:
+   - `aws sts get-caller-identity --query "Account" --output text`
+5. Generate `./.tmp/resource-mapping.json` (not committed) and run:
+   - `pnpm exec cdk import <STACK_NAME> --resource-mapping ./.tmp/resource-mapping.json`
+6. Run `pnpm exec cdk diff` for verification
+
+## Resource mapping
+
+No AWS account IDs are stored in source control.
+
+- Template file: `config/resource-mapping.template.json`
+- Runtime file: `./.tmp/resource-mapping.json`
+
+The generated ARN format is:
+
+`arn:aws:iam::<ACCOUNT_ID>:oidc-provider/token.actions.githubusercontent.com`
+
+## Reference
+
+- [AWS CDK `cdk import` docs](https://docs.aws.amazon.com/cdk/v2/guide/ref-cli-cmd-import.html)

--- a/migration-test/README.md
+++ b/migration-test/README.md
@@ -33,6 +33,12 @@ pnpm install
 pnpm run test-migration
 ```
 
+Run with automatic teardown (no prompt at the end):
+
+```sh
+bash ./scripts/run-migration.sh --teardown
+```
+
 Optional environment variable:
 
 - `MIGRATION_STACK_NAME` (default: `AwsCdkGithubOidcMigrationTest`)
@@ -49,6 +55,11 @@ Optional environment variable:
 5. Generate `./.tmp/resource-mapping.json` (not committed) and run:
    - `pnpm exec cdk import <STACK_NAME> --resource-mapping ./.tmp/resource-mapping.json`
 6. Run `pnpm exec cdk diff` for verification
+
+After step 6, the script asks whether to delete the test stack.
+- Reply `y` or `yes` to destroy it.
+- Reply `n` to keep it deployed.
+- Use `--teardown` (or `--teardown=true`) to destroy without prompting.
 
 ## Resource mapping
 

--- a/migration-test/bin/app.ts
+++ b/migration-test/bin/app.ts
@@ -1,0 +1,8 @@
+import * as cdk from "aws-cdk-lib";
+import { MigrationTestStack } from "../lib/migration-test-stack";
+
+const app = new cdk.App();
+const stackName =
+  process.env.MIGRATION_STACK_NAME ?? "AwsCdkGithubOidcMigrationTest";
+
+new MigrationTestStack(app, stackName);

--- a/migration-test/cdk.json
+++ b/migration-test/cdk.json
@@ -1,0 +1,6 @@
+{
+  "app": "pnpm exec tsx bin/app.ts",
+  "context": {
+    "@aws-cdk/core:newStyleStackSynthesis": true
+  }
+}

--- a/migration-test/config/resource-mapping.template.json
+++ b/migration-test/config/resource-mapping.template.json
@@ -1,0 +1,5 @@
+{
+  "GithubProvider1CDE27EB": {
+    "Arn": "arn:aws:iam::__ACCOUNT_ID__:oidc-provider/token.actions.githubusercontent.com"
+  }
+}

--- a/migration-test/lib/migration-test-stack.ts
+++ b/migration-test/lib/migration-test-stack.ts
@@ -1,0 +1,77 @@
+import * as cdk from "aws-cdk-lib";
+import * as iam from "aws-cdk-lib/aws-iam";
+import {
+  GithubActionsIdentityProvider,
+  GithubActionsRole,
+  IGithubActionsIdentityProvider,
+} from "aws-cdk-github-oidc";
+import { Construct } from "constructs";
+
+type MigrationPhase = "v2" | "v3-retain" | "v4-lookup" | "v4-import";
+
+function isMigrationPhase(value: string): value is MigrationPhase {
+  return (
+    value === "v2" ||
+    value === "v3-retain" ||
+    value === "v4-lookup" ||
+    value === "v4-import"
+  );
+}
+
+function resolvePhase(): MigrationPhase {
+  const phase = process.env.MIGRATION_PHASE ?? "v2";
+  if (isMigrationPhase(phase)) {
+    return phase;
+  }
+  throw new Error(
+    `Invalid MIGRATION_PHASE="${phase}". Valid values: v2, v3-retain, v4-lookup, v4-import.`,
+  );
+}
+
+function createProvider(
+  scope: Construct,
+  phase: MigrationPhase,
+): IGithubActionsIdentityProvider {
+  if (phase === "v4-lookup") {
+    return GithubActionsIdentityProvider.fromAccount(
+      scope,
+      "GithubProviderReference",
+    );
+  }
+
+  const shouldRetain = phase === "v3-retain" || phase === "v4-import";
+  const ProviderCtor = GithubActionsIdentityProvider as unknown as new (
+    scope: Construct,
+    id: string,
+    props?: { removalPolicy?: cdk.RemovalPolicy },
+  ) => IGithubActionsIdentityProvider;
+  return new ProviderCtor(scope, "GithubProvider", {
+    removalPolicy: shouldRetain ? cdk.RemovalPolicy.RETAIN : undefined,
+  });
+}
+
+export class MigrationTestStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const phase = resolvePhase();
+    const provider = createProvider(this, phase);
+
+    new GithubActionsRole(this, "GithubActionsRole", {
+      provider,
+      owner: "octo-org",
+      repo: "octo-repo",
+      filter: "ref:refs/heads/main",
+      roleName: "migration-test-github-actions-role",
+      description: "Role for validating aws-cdk-github-oidc migration flow",
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName("ReadOnlyAccess"),
+      ],
+    });
+
+    new cdk.CfnOutput(this, "MigrationPhase", { value: phase });
+    new cdk.CfnOutput(this, "ProviderArn", {
+      value: `arn:${cdk.Aws.PARTITION}:iam::${cdk.Aws.ACCOUNT_ID}:oidc-provider/${GithubActionsIdentityProvider.issuer}`,
+    });
+  }
+}

--- a/migration-test/package.json
+++ b/migration-test/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "migration-test",
+  "private": true,
+  "packageManager": "pnpm@10.19.0",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "cdk": "pnpm exec cdk",
+    "synth": "pnpm exec cdk synth",
+    "diff": "pnpm exec cdk diff",
+    "deploy": "pnpm exec cdk deploy --require-approval never",
+    "test-migration": "bash ./scripts/run-migration.sh"
+  },
+  "dependencies": {
+    "aws-cdk-github-oidc": "^2.4.1",
+    "aws-cdk-lib": "2.220.0",
+    "constructs": "^10.3.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "aws-cdk": "^2",
+    "tsx": "^4",
+    "typescript": "^5"
+  }
+}

--- a/migration-test/pnpm-lock.yaml
+++ b/migration-test/pnpm-lock.yaml
@@ -1,0 +1,423 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      aws-cdk-github-oidc:
+        specifier: ^2.4.1
+        version: 2.4.1(aws-cdk-lib@2.220.0(constructs@10.6.0))(constructs@10.6.0)
+      aws-cdk-lib:
+        specifier: 2.220.0
+        version: 2.220.0(constructs@10.6.0)
+      constructs:
+        specifier: ^10.3.0
+        version: 10.6.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.40
+      aws-cdk:
+        specifier: ^2
+        version: 2.1121.0
+      tsx:
+        specifier: ^4
+        version: 4.21.0
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+
+packages:
+
+  '@aws-cdk/asset-awscli-v1@2.2.242':
+    resolution: {integrity: sha512-4c1bAy2ISzcdKXYS1k4HYZsNrgiwbiDzj36ybwFVxEWZXVAP0dimQTCaB9fxu7sWzEjw3d+eaw6Fon+QTfTIpQ==}
+
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.1':
+    resolution: {integrity: sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA==}
+
+  '@aws-cdk/cloud-assembly-schema@48.20.0':
+    resolution: {integrity: sha512-+eeiav9LY4wbF/EFuCt/vfvi/Zoxo8bf94PW5clbMraChEliq83w4TbRVy0jB9jE0v1ooFTtIjSQkowSPkfISg==}
+    engines: {node: '>= 18.0.0'}
+    bundledDependencies:
+      - jsonschema
+      - semver
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/node@20.19.40':
+    resolution: {integrity: sha512-xxx6M2IpSTnnKcR0cMvIiohkiCx20/oRPtWGbenFygKCGl3zqUzdNjQ/1V4solq1LU+dgv0nQzeGOuqkqZGg0Q==}
+
+  aws-cdk-github-oidc@2.4.1:
+    resolution: {integrity: sha512-zKQYPGyf5f6APG76OpOxW6P7KGY/fC6VhN1ZullxySSu6RroUH9VtVl+cJ8hYes5XvEE/ZDpx2h2fPtNwZrcVQ==}
+    engines: {node: '>= 16.20.0'}
+    peerDependencies:
+      aws-cdk-lib: ^2.89.0
+      constructs: ^10.0.0
+
+  aws-cdk-lib@2.220.0:
+    resolution: {integrity: sha512-mOEyPP1ymWiLnSE0xFxWjG00E1DQ5wtbcgKUmtGjxyNdoG/Qret1nDLqE43YGZEbwca43WO/a2LDuSL6+hN7Lg==}
+    engines: {node: '>= 18.0.0'}
+    peerDependencies:
+      constructs: ^10.0.0
+    bundledDependencies:
+      - '@balena/dockerignore'
+      - case
+      - fs-extra
+      - ignore
+      - jsonschema
+      - minimatch
+      - punycode
+      - semver
+      - table
+      - yaml
+      - mime-types
+
+  aws-cdk@2.1121.0:
+    resolution: {integrity: sha512-cG7CHt/SytYTfwrK+BUNQpqmS1dwhjt8z6ExKL6GK4n+8/6ZCwFzxlZWA/jUd2+Y9xPc+Q8cLKfMqGmgxEXbkg==}
+    engines: {node: '>= 18.0.0'}
+    hasBin: true
+
+  constructs@10.6.0:
+    resolution: {integrity: sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+snapshots:
+
+  '@aws-cdk/asset-awscli-v1@2.2.242': {}
+
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.1': {}
+
+  '@aws-cdk/cloud-assembly-schema@48.20.0': {}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@types/node@20.19.40':
+    dependencies:
+      undici-types: 6.21.0
+
+  aws-cdk-github-oidc@2.4.1(aws-cdk-lib@2.220.0(constructs@10.6.0))(constructs@10.6.0):
+    dependencies:
+      aws-cdk-lib: 2.220.0(constructs@10.6.0)
+      constructs: 10.6.0
+
+  aws-cdk-lib@2.220.0(constructs@10.6.0):
+    dependencies:
+      '@aws-cdk/asset-awscli-v1': 2.2.242
+      '@aws-cdk/asset-node-proxy-agent-v6': 2.1.1
+      '@aws-cdk/cloud-assembly-schema': 48.20.0
+      constructs: 10.6.0
+
+  aws-cdk@2.1121.0: {}
+
+  constructs@10.6.0: {}
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  resolve-pkg-maps@1.0.0: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}

--- a/migration-test/pnpm-workspace.yaml
+++ b/migration-test/pnpm-workspace.yaml
@@ -1,0 +1,21 @@
+# Copied from repository root pnpm-workspace.yaml to keep identical pnpm policies
+# while keeping migration-test dependency changes isolated.
+
+minimumReleaseAge: 4320
+minimumReleaseAgeExclude:
+  - "@alma-cdk/construct-library"
+  - "aws-cdk-github-oidc"
+trustPolicy: no-downgrade
+trustPolicyIgnoreAfter: 20160
+trustPolicyExclude:
+  - jsii@5.9.33
+  - jsii@5.9.35
+nodeLinker: hoisted
+resolutionMode: highest
+strictDepBuilds: true
+onlyBuiltDependencies:
+  - unrs-resolver
+  - lefthook
+  - esbuild
+blockExoticSubdeps: true
+overrides: {}

--- a/migration-test/scripts/run-migration.sh
+++ b/migration-test/scripts/run-migration.sh
@@ -170,7 +170,7 @@ if [[ "${AUTO_TEARDOWN}" == "true" ]]; then
   teardown_stack
 else
   read -r -p "Teardown test stack now? (y/n) " teardown_answer
-  teardown_answer="${teardown_answer,,}"
+  teardown_answer="$(printf '%s' "${teardown_answer}" | tr '[:upper:]' '[:lower:]')"
   if [[ "${teardown_answer}" == "y" || "${teardown_answer}" == "yes" ]]; then
     teardown_stack
   else

--- a/migration-test/scripts/run-migration.sh
+++ b/migration-test/scripts/run-migration.sh
@@ -5,6 +5,51 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 cd "${PROJECT_DIR}"
 
+AUTO_TEARDOWN="false"
+
+usage() {
+  cat <<EOF
+Usage: ./scripts/run-migration.sh [--teardown[=true|false]]
+
+Options:
+  --teardown            Perform teardown automatically without asking.
+  --teardown=true       Same as --teardown.
+  --teardown=false      Skip automatic teardown and ask at the end.
+  -h, --help            Show this help message.
+EOF
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --teardown)
+      if (($# > 1)) && [[ "$2" =~ ^(true|false)$ ]]; then
+        AUTO_TEARDOWN="$2"
+        shift 2
+      else
+        AUTO_TEARDOWN="true"
+        shift
+      fi
+      ;;
+    --teardown=*)
+      AUTO_TEARDOWN="${1#*=}"
+      if [[ "${AUTO_TEARDOWN}" != "true" && "${AUTO_TEARDOWN}" != "false" ]]; then
+        echo "Invalid value for --teardown: ${AUTO_TEARDOWN} (expected true|false)" >&2
+        exit 1
+      fi
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
 STACK_NAME="${MIGRATION_STACK_NAME:-AwsCdkGithubOidcMigrationTest}"
 TMP_DIR="${PROJECT_DIR}/.tmp"
 RESOURCE_MAPPING_PATH="${TMP_DIR}/resource-mapping.json"
@@ -13,6 +58,12 @@ ACCOUNT_ID="$(aws sts get-caller-identity --query "Account" --output text)"
 CALLER_ARN="$(aws sts get-caller-identity --query "Arn" --output text)"
 AWS_PARTITION="$(echo "${CALLER_ARN}" | cut -d: -f2)"
 OIDC_PROVIDER_ARN="arn:${AWS_PARTITION}:iam::${ACCOUNT_ID}:oidc-provider/${OIDC_ISSUER}"
+
+cleanup_tmp_artifacts() {
+  rm -f "${RESOURCE_MAPPING_PATH}"
+}
+
+trap cleanup_tmp_artifacts EXIT
 
 verify_stack_status() {
   local context="$1"
@@ -62,10 +113,16 @@ verify_oidc_provider_present() {
   echo "Verified OIDC provider after ${context}: ${OIDC_PROVIDER_ARN}"
 }
 
+teardown_stack() {
+  echo "==> Teardown: Destroying stack ${STACK_NAME}"
+  MIGRATION_PHASE=v4-import MIGRATION_STACK_NAME="${STACK_NAME}" pnpm exec cdk destroy "${STACK_NAME}" --force
+}
+
 echo "Using stack: ${STACK_NAME}"
 echo "Working directory: ${PROJECT_DIR}"
 echo "Using account: ${ACCOUNT_ID}"
 echo "Using OIDC provider ARN: ${OIDC_PROVIDER_ARN}"
+echo "Auto teardown: ${AUTO_TEARDOWN}"
 
 mkdir -p "${TMP_DIR}"
 
@@ -98,7 +155,8 @@ cat > "${RESOURCE_MAPPING_PATH}" <<EOF
 }
 EOF
 
-MIGRATION_PHASE=v4-import MIGRATION_STACK_NAME="${STACK_NAME}" pnpm exec cdk import "${STACK_NAME}" --resource-mapping "${RESOURCE_MAPPING_PATH}"
+echo "Running non-interactive import..."
+printf "y\ny\n" | MIGRATION_PHASE=v4-import MIGRATION_STACK_NAME="${STACK_NAME}" pnpm exec cdk import "${STACK_NAME}" --resource-mapping "${RESOURCE_MAPPING_PATH}" --force --execute true --require-approval never
 verify_stack_status "phase 4 import" IMPORT_COMPLETE
 verify_oidc_provider_present "phase 4 import"
 
@@ -107,3 +165,15 @@ MIGRATION_PHASE=v4-import MIGRATION_STACK_NAME="${STACK_NAME}" pnpm exec cdk dif
 verify_oidc_provider_present "phase 5 post-import diff"
 
 echo "Migration test flow completed successfully."
+
+if [[ "${AUTO_TEARDOWN}" == "true" ]]; then
+  teardown_stack
+else
+  read -r -p "Teardown test stack now? (y/n) " teardown_answer
+  teardown_answer="${teardown_answer,,}"
+  if [[ "${teardown_answer}" == "y" || "${teardown_answer}" == "yes" ]]; then
+    teardown_stack
+  else
+    echo "Skipping teardown. Stack remains deployed: ${STACK_NAME}"
+  fi
+fi

--- a/migration-test/scripts/run-migration.sh
+++ b/migration-test/scripts/run-migration.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${PROJECT_DIR}"
+
+STACK_NAME="${MIGRATION_STACK_NAME:-AwsCdkGithubOidcMigrationTest}"
+TMP_DIR="${PROJECT_DIR}/.tmp"
+RESOURCE_MAPPING_PATH="${TMP_DIR}/resource-mapping.json"
+OIDC_ISSUER="token.actions.githubusercontent.com"
+ACCOUNT_ID="$(aws sts get-caller-identity --query "Account" --output text)"
+CALLER_ARN="$(aws sts get-caller-identity --query "Arn" --output text)"
+AWS_PARTITION="$(echo "${CALLER_ARN}" | cut -d: -f2)"
+OIDC_PROVIDER_ARN="arn:${AWS_PARTITION}:iam::${ACCOUNT_ID}:oidc-provider/${OIDC_ISSUER}"
+
+verify_stack_status() {
+  local context="$1"
+  shift
+  local status
+  status="$(aws cloudformation describe-stacks --stack-name "${STACK_NAME}" --query "Stacks[0].StackStatus" --output text)"
+
+  for expected in "$@"; do
+    if [[ "${status}" == "${expected}" ]]; then
+      echo "Verified stack status after ${context}: ${status}"
+      return 0
+    fi
+  done
+
+  echo "Unexpected stack status after ${context}: ${status}" >&2
+  echo "Expected one of: $*" >&2
+  exit 1
+}
+
+verify_oidc_provider_present() {
+  local context="$1"
+  local listed_arn
+  listed_arn="$(
+    aws iam list-open-id-connect-providers \
+      --query "OpenIDConnectProviderList[?Arn=='${OIDC_PROVIDER_ARN}'].Arn | [0]" \
+      --output text
+  )"
+
+  if [[ "${listed_arn}" != "${OIDC_PROVIDER_ARN}" ]]; then
+    echo "OIDC provider not found after ${context}: ${OIDC_PROVIDER_ARN}" >&2
+    exit 1
+  fi
+
+  local provider_url
+  provider_url="$(
+    aws iam get-open-id-connect-provider \
+      --open-id-connect-provider-arn "${OIDC_PROVIDER_ARN}" \
+      --query "Url" \
+      --output text
+  )"
+
+  if [[ "${provider_url}" != "${OIDC_ISSUER}" ]]; then
+    echo "OIDC provider URL mismatch after ${context}: expected ${OIDC_ISSUER}, got ${provider_url}" >&2
+    exit 1
+  fi
+
+  echo "Verified OIDC provider after ${context}: ${OIDC_PROVIDER_ARN}"
+}
+
+echo "Using stack: ${STACK_NAME}"
+echo "Working directory: ${PROJECT_DIR}"
+echo "Using account: ${ACCOUNT_ID}"
+echo "Using OIDC provider ARN: ${OIDC_PROVIDER_ARN}"
+
+mkdir -p "${TMP_DIR}"
+
+echo "==> Phase 1: Install v2 + aws-cdk-lib@2.220.0"
+pnpm add aws-cdk-github-oidc@^2 aws-cdk-lib@2.220.0
+MIGRATION_PHASE=v2 MIGRATION_STACK_NAME="${STACK_NAME}" pnpm exec cdk deploy "${STACK_NAME}" --require-approval never
+verify_stack_status "phase 1 deploy" CREATE_COMPLETE UPDATE_COMPLETE
+verify_oidc_provider_present "phase 1 deploy"
+
+echo "==> Phase 2: Upgrade to v3.1 + aws-cdk-lib@2.237.0 with RETAIN"
+pnpm add aws-cdk-github-oidc@^3.1 aws-cdk-lib@2.237.0
+MIGRATION_PHASE=v3-retain MIGRATION_STACK_NAME="${STACK_NAME}" pnpm exec cdk diff "${STACK_NAME}"
+MIGRATION_PHASE=v3-retain MIGRATION_STACK_NAME="${STACK_NAME}" pnpm exec cdk deploy "${STACK_NAME}" --require-approval never
+verify_stack_status "phase 2 deploy" CREATE_COMPLETE UPDATE_COMPLETE
+verify_oidc_provider_present "phase 2 deploy"
+
+echo "==> Phase 3: Upgrade to v4.2 + aws-cdk-lib@^2.237.0 and lookup provider"
+pnpm add aws-cdk-github-oidc@^4.2 aws-cdk-lib@^2.237.0
+MIGRATION_PHASE=v4-lookup MIGRATION_STACK_NAME="${STACK_NAME}" pnpm exec cdk diff "${STACK_NAME}"
+MIGRATION_PHASE=v4-lookup MIGRATION_STACK_NAME="${STACK_NAME}" pnpm exec cdk deploy "${STACK_NAME}" --require-approval never
+verify_stack_status "phase 3 deploy" CREATE_COMPLETE UPDATE_COMPLETE
+verify_oidc_provider_present "phase 3 deploy"
+
+echo "==> Phase 4: Switch back to managed provider and import"
+cat > "${RESOURCE_MAPPING_PATH}" <<EOF
+{
+  "GithubProvider1CDE27EB": {
+    "Arn": "${OIDC_PROVIDER_ARN}"
+  }
+}
+EOF
+
+MIGRATION_PHASE=v4-import MIGRATION_STACK_NAME="${STACK_NAME}" pnpm exec cdk import "${STACK_NAME}" --resource-mapping "${RESOURCE_MAPPING_PATH}"
+verify_stack_status "phase 4 import" IMPORT_COMPLETE
+verify_oidc_provider_present "phase 4 import"
+
+echo "==> Phase 5: Post-import verification"
+MIGRATION_PHASE=v4-import MIGRATION_STACK_NAME="${STACK_NAME}" pnpm exec cdk diff "${STACK_NAME}"
+verify_oidc_provider_present "phase 5 post-import diff"
+
+echo "Migration test flow completed successfully."


### PR DESCRIPTION
This pull request introduces a comprehensive migration test harness for `aws-cdk-github-oidc`, enabling automated validation of migration flows across multiple major versions. The harness is implemented as an isolated CDK app with supporting scripts and configuration, and it programmatically exercises upgrade, resource retention, lookup, and import scenarios. The most important changes are as follows:

**Migration Test Harness Implementation**
- Added a new `migration-test` directory containing a standalone CDK app, which can switch between different `aws-cdk-github-oidc` versions and migration phases using the `MIGRATION_PHASE` environment variable. The app includes logic to create, retain, look up, and import the OIDC provider resource, validating real-world migration flows. (`migration-test/lib/migration-test-stack.ts`, [migration-test/lib/migration-test-stack.tsR1-R77](diffhunk://#diff-88cb54b019b0143e7a63c890af0046ab165bdf4e03f1adccf9b7ac9abda295f6R1-R77))
- Added a shell script (`scripts/run-migration.sh`) that automates the full migration sequence, including dependency upgrades, stack deployments, resource lookups, and post-import verification, ensuring end-to-end coverage. (`migration-test/scripts/run-migration.sh`, [migration-test/scripts/run-migration.shR1-R109](diffhunk://#diff-0302ca13ec60978346aa50bb7f844965530ac0e4f4fd4a0806b46ebc36e95b87R1-R109))

**Configuration and Documentation**
- Added a detailed `README.md` describing the migration flow, stack behavior in each phase, setup instructions, and resource mapping process. (`migration-test/README.md`, [migration-test/README.mdR1-R66](diffhunk://#diff-aa43de97ad2477d372484e2aed1e0b7024baeb30819702cdd9fea48b15f5f70eR1-R66))
- Added `cdk.json`, `package.json`, and `pnpm-workspace.yaml` to configure the CDK app, dependency management, and workspace policies, ensuring isolated and reproducible test runs. (`migration-test/cdk.json`, [[1]](diffhunk://#diff-b4d6ebfb623bbc6cbe65627da2df21bcbdfb14272928f7741eed9ddca1e17d4eR1-R6); `migration-test/package.json`, [[2]](diffhunk://#diff-5eab933673a98217f0336caa083c00961da7e2c7045b81d59dc07d386585bb01R1-R24); `migration-test/pnpm-workspace.yaml`, [[3]](diffhunk://#diff-4d1633dc6f8141b8038891f22de24995c9a5518b101e238804ac81f65c3a697cR1-R21)

**Resource Mapping and Ignore Files**
- Added a template for resource mapping (`config/resource-mapping.template.json`) to support the CDK import process without hardcoding account IDs. (`migration-test/config/resource-mapping.template.json`, [migration-test/config/resource-mapping.template.jsonR1-R5](diffhunk://#diff-4048ddc80445c46fb935d408aaf3fa0d5533d312789a96f37629074fadcf8dcaR1-R5))
- Updated `.gitignore` to exclude build artifacts, `node_modules`, and temporary files from version control. (`migration-test/.gitignore`, [migration-test/.gitignoreR1-R3](diffhunk://#diff-ad7b77449b86d286b81a3041a0b5d49ee4244800d94def5f60e57a0a369bed30R1-R3))